### PR TITLE
[HUDI-8126] Support proto messages for spark kryo serializer

### DIFF
--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -93,6 +93,12 @@
       <artifactId>parquet-avro</artifactId>
     </dependency>
 
+    <!-- Used for adding kryo serializers for protobuf -->
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-protobuf</artifactId>
+    </dependency>
+
     <!-- Hoodie - Test -->
     <dependency>
       <groupId>org.apache.hudi</groupId>

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/ProtobufDynamicMessageSerializer.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/ProtobufDynamicMessageSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark;
+
+import org.apache.hudi.exception.HoodieIOException;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * ProtobufDynamicMessageSerializer is a kryo serializer for proto dynamic messages.
+ * ProtobufSerializer available in chill library (<a href="https://github.com/twitter/chill/blob/master/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java">...</a>)
+ * uses parseFrom(byte[]..) method available in compiled proto messages. DynamicMessage doesn't have this method, and we need to handle this serialization through a concurrent hash map.
+ */
+public class ProtobufDynamicMessageSerializer extends Serializer<DynamicMessage> {
+
+  @Override
+  public void write(Kryo kryo, Output output, DynamicMessage dynamicMessage) {
+    // Write the message type to the output stream
+    String messageType = dynamicMessage.getDescriptorForType().getFullName();
+    output.writeString(messageType);
+    // Serialize the Descriptor into bytes and write the length followed by the bytes
+    DescriptorProtos.DescriptorProto descriptorProto = dynamicMessage.getDescriptorForType().toProto();
+    byte[] descriptorBytes = descriptorProto.toByteArray();
+    output.writeInt(descriptorBytes.length);
+    output.writeBytes(descriptorBytes);
+    // Serialize the DynamicMessage into bytes and write the length followed by the bytes
+    byte[] messageBytes = dynamicMessage.toByteArray();
+    output.writeInt(messageBytes.length);
+    output.writeBytes(messageBytes);
+  }
+
+  @Override
+  public DynamicMessage read(Kryo kryo, Input input, Class<DynamicMessage> aClass) {
+    try {
+      String messageType = input.readString();
+      // Lookup the Descriptor from the bytes.
+      int descriptorLength = input.readInt();
+      byte[] descriptorBytes = input.readBytes(descriptorLength);
+      Descriptors.Descriptor descriptor = DescriptorProtos.DescriptorProto.parseFrom(descriptorBytes).getDescriptorForType();
+      if (descriptor == null) {
+        throw new IllegalArgumentException("Descriptor does not match for messageType: " + messageType);
+      }
+      // Read the serialized bytes
+      int messageLength = input.readInt();
+      byte[] messageBytes = input.readBytes(messageLength);
+      // Deserialize the DynamicMessage using the descriptor
+      return DynamicMessage.parseFrom(descriptor, messageBytes);
+    } catch (InvalidProtocolBufferException e) {
+      throw new HoodieIOException("Failed to deserialize DynamicMessage", e);
+    }
+  }
+}
+

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/TestProtobufDynamicMessageSerializer.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/spark/TestProtobufDynamicMessageSerializer.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark;
+
+import org.apache.hudi.exception.HoodieIOException;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestProtobufDynamicMessageSerializer {
+
+  private ProtobufDynamicMessageSerializer serializer;
+  private Kryo kryo;
+  private Output output;
+  private Input input;
+
+  @BeforeEach
+  public void setUp() {
+    serializer = new ProtobufDynamicMessageSerializer();
+    kryo = new Kryo();
+  }
+
+  @Test
+  void testWriteAndRead() throws Exception {
+    // Define a simple proto schema for testing
+    DescriptorProtos.DescriptorProto descriptorProto = DescriptorProtos.DescriptorProto.newBuilder()
+        .setName("TestMessage")
+        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+            .setName("testField")
+            .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+            .setNumber(1))
+        .build();
+    Descriptors.Descriptor descriptor = Descriptors.FileDescriptor
+        .buildFrom(DescriptorProtos.FileDescriptorProto.newBuilder()
+            .addMessageType(descriptorProto)
+            .build(), new Descriptors.FileDescriptor[] {})
+        .findMessageTypeByName("TestMessage");
+    DynamicMessage dynamicMessage = DynamicMessage.newBuilder(descriptor)
+        .setField(descriptor.findFieldByName("testField"), "testValue")
+        .build();
+    // Serialize the DynamicMessage
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    output = new Output(byteArrayOutputStream);
+    serializer.write(kryo, output, dynamicMessage);
+    output.close();
+    // Deserialize the DynamicMessage
+    byte[] serializedBytes = byteArrayOutputStream.toByteArray();
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serializedBytes);
+    input = new Input(byteArrayInputStream);
+    DynamicMessage deserializedMessage = serializer.read(kryo, input, DynamicMessage.class);
+    // Verify that the deserialized message is the same as the original
+    assertNotNull(deserializedMessage);
+    assertArrayEquals(dynamicMessage.toByteArray(), deserializedMessage.toByteArray());
+  }
+
+  @Test
+  void testInvalidMessageBytes() {
+    // Mock an input to simulate a failure during DynamicMessage parsing
+    Input mockInput = mock(Input.class);
+    when(mockInput.readString()).thenReturn("TestMessage");
+    when(mockInput.readInt()).thenReturn(10);  // Invalid descriptor length
+    when(mockInput.readBytes(anyInt())).thenReturn(new byte[] {0x01});  // Invalid descriptor data
+    // This should throw a HoodieIOException due to invalid bytes
+    assertThrows(HoodieIOException.class, () -> serializer.read(kryo, mockInput, DynamicMessage.class));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestProtoKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestProtoKafkaSource.java
@@ -40,6 +40,7 @@ import com.google.protobuf.DoubleValue;
 import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt32Value;
@@ -69,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -127,8 +129,16 @@ public class TestProtoKafkaSource extends BaseTestKafkaSource {
     sendMessagesToKafkaWithConfluentSerializer(topic, 2, messages);
     // Assert messages are read correctly
     JavaRDD<Message> messagesRead = protoKafkaSource.fetchNext(Option.empty(), 1000).getBatch().get();
-    assertEquals(messages.stream().map(this::protoToJson).collect(Collectors.toSet()),
-        new HashSet<>(messagesRead.map(message -> PRINTER.print(message)).collect()));
+    List<Message> protoMessages = messagesRead.collect();
+    assertEquals(1000, protoMessages.size());
+    Set<Sample> messagesConsumed = protoMessages.stream().map(message -> {
+      try {
+        return Sample.parseFrom(message.toByteArray());
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.toSet());
+    assertEquals(new HashSet<>(messages), messagesConsumed);
     verifyRddsArePersisted(protoKafkaSource, messagesRead.rdd().toDebugString(), persistSourceRdd);
   }
 
@@ -140,6 +150,7 @@ public class TestProtoKafkaSource extends BaseTestKafkaSource {
     testUtils.createTopic(topic, 2);
     TypedProperties props = createPropsForKafkaSource(topic, null, "earliest");
     props.setProperty(ProtoClassBasedSchemaProviderConfig.PROTO_SCHEMA_WRAPPED_PRIMITIVES_AS_RECORDS.key(), "true");
+    props.setProperty(HoodieErrorTableConfig.ERROR_TABLE_PERSIST_SOURCE_RDD.key(), "true");
     SchemaProvider schemaProvider = new ProtoClassBasedSchemaProvider(props, jsc());
     Source protoKafkaSource = new ProtoKafkaSource(props, jsc(), spark(), schemaProvider, metrics);
     SourceFormatAdapter kafkaSource = new SourceFormatAdapter(protoKafkaSource);

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
     <presto.bundle.bootstrap.shade.prefix>org.apache.hudi.</presto.bundle.bootstrap.shade.prefix>
     <trino.bundle.bootstrap.scope>compile</trino.bundle.bootstrap.scope>
     <trino.bundle.bootstrap.shade.prefix>org.apache.hudi.</trino.bundle.bootstrap.shade.prefix>
+    <twitter.chill.version>0.10.0</twitter.chill.version>
     <shadeSources>true</shadeSources>
     <zk-curator.version>2.7.1</zk-curator.version>
     <disruptor.version>3.4.2</disruptor.version>
@@ -1732,6 +1733,13 @@
         <artifactId>kryo</artifactId>
         <version>4.0.0</version>
         <scope>test</scope>
+      </dependency>
+
+      <!-- Used for adding kryo serializers for protobuf -->
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-protobuf</artifactId>
+        <version>${twitter.chill.version}</version>
       </dependency>
 
       <!-- Other Utils -->


### PR DESCRIPTION
### Change Logs

Persisting a proto RDD<Message> is failing because KyroSerializer in Spark doesn't have handling for proto messages and failing with errors like this.

```
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException
Serialization trace:
domains_ (com.conductor.serp.canonical.ConductorCanonicalSerpProtos$ParsedUrl)
parsedUrl_ (com.conductor.serp.canonical.ConductorCanonicalSerpProtos$CanonicalSerpItem)
	at com.esotericsoftware.kryo.serializers.ObjectField.read(ObjectField.java:144)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:543)
	at com.esotericsoftware.kryo.Kryo.readObjectOrNull(Kryo.java:782)
	at com.esotericsoftware.kryo.serializers.ObjectField.read(ObjectField.java:132)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:543)
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:813)
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.read(CollectionSerializer.java:134)
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.read(CollectionSerializer.java:40)
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:813)
	at com.twitter.chill.java.UnmodifiableJavaCollectionSerializer.read(UnmodifiableJavaCollectionSerializer.java:59)
	... 69 more
```

Spark already uses the [scala kryo serializers](https://github.com/onehouseinc/spark-internal/blob/master/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala#L199) provided by https://github.com/twitter/chill, this PR includes the proto one as well.

Added another class `ProtobufDynamicMessageSerializer` to handle dynamic messages as the default available in chill library uses `parseFrom(byte[]..)` method available in compiled proto messages. DynamicMessage doesn't have this method, and we need to handle this serialization through descriptors.

### Impact

No impact on existing functionality, improving `HoodieSparkKryoRegistrar` to handle proto messages as well.

### Risk level (write none, low medium or high below)

Medium. 

### Documentation Update

None

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Change Logs and Impact were stated clearly
- [x] Adequate tests were added if applicable
- [x] CI passed
